### PR TITLE
Fixed #162: Unable to install BeSman

### DIFF
--- a/scripts/tmpl/get.besman.io.tmpl
+++ b/scripts/tmpl/get.besman.io.tmpl
@@ -22,10 +22,10 @@ then
 fi
 
 echo "Checking version number"
-releases=$(curl -s --silent "https://api.github.com/repos/$BESMAN_NAMESPACE/BESMAN/releases" | jq -r '.[].tag_name')
-
-if ! echo "$releases" | grep -q "^$BESMAN_VERSION$"; then
-	echo "Version $BESMAN_VERSION is not a valid release in repository $repo."
+release=$(curl -s --insecure --silent "https://api.github.com/repos/$BESMAN_NAMESPACE/BeSman/releases" | jq -r '.[].tag_name' | grep "^$BESMAN_VERSION$")
+if [[ -z $release ]] 
+then
+    echo "Version $release is not a valid version of $BESMAN_NAMESPACE/BeSman"
 	exit 1
 fi
 
@@ -304,7 +304,7 @@ echo "Download script archive..."
 
 # once move to besman namespace needs to update besman-latest.zip 
 #curl -sL --location --progress-bar "${BESMAN_SERVICE}/${BESMAN_NAMESPACE}/BESman/dist/dist/besman-latest.zip" > "$besman_zip_file"
-curl -sL --location --progress-bar "${BESMAN_SERVICE}/${BESMAN_NAMESPACE}/BeSman/dist/dist/besman-latest.zip" > "$besman_zip_file"
+curl -sL --location --progress-bar "${BESMAN_SERVICE}/${BESMAN_NAMESPACE}/BeSman/dist/dist/besman-$BESMAN_VERSION.zip" > "$besman_zip_file"
 #cp "/vagrant/ProEnv/besman-latest.zip"  "$besman_zip_file"
 
 


### PR DESCRIPTION
There was a typo in the repo name when checking whether the version is valid.

Fix #162 